### PR TITLE
Changed flag for shipping fee

### DIFF
--- a/billmateinvoice/controllers/front/getaddress.php
+++ b/billmateinvoice/controllers/front/getaddress.php
@@ -532,7 +532,7 @@ class BillmateInvoiceGetaddressModuleFrontController extends ModuleFrontControll
 						'price'    => (int)($shippingPrice*100),
 						'vat'      => (float)$taxrate,
 						'discount' => 0.0,
-						'flags'    => 16, //16|32
+						'flags'    => 8,
 					)
 				);
 			}


### PR DESCRIPTION
Old flag was 16, the sum was then handeld as service fee. New should flag should be 8 as it will be set as shipping fee excluding VAT.